### PR TITLE
feat: add to_dict method to easily serialise output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate zxcvbn;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use std::fmt;
 
 #[pyclass(eq, eq_int)]
@@ -30,6 +31,16 @@ fn match_score(score: zxcvbn::Score) -> Result<Score, PyErr> {
         _ => Err(PyRuntimeError::new_err(
             "zxcvbn entropy score must be in the range 0-4",
         )),
+    }
+}
+
+fn score_to_u8(score: &Score) -> u8 {
+    match score {
+        Score::ZERO => 0,
+        Score::ONE => 1,
+        Score::TWO => 2,
+        Score::THREE => 3,
+        Score::FOUR => 4,
     }
 }
 
@@ -322,6 +333,76 @@ struct Entropy {
     /// How long it took to calculate the answer.
     #[pyo3(get)]
     calc_time: u128,
+}
+
+#[pymethods]
+impl Entropy {
+    fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let result = PyDict::new(py);
+
+        result.set_item("guesses", self.guesses)?;
+        result.set_item("guesses_log10", self.guesses_log10)?;
+
+        let crack_times_seconds = PyDict::new(py);
+        crack_times_seconds.set_item(
+            "offline_fast_hashing_1e10_per_second",
+            self.crack_times_seconds.offline_fast_hashing_1e10_per_second,
+        )?;
+        crack_times_seconds.set_item(
+            "offline_slow_hashing_1e4_per_second",
+            self.crack_times_seconds.offline_slow_hashing_1e4_per_second,
+        )?;
+        crack_times_seconds.set_item(
+            "online_no_throttling_10_per_second",
+            self.crack_times_seconds.online_no_throttling_10_per_second,
+        )?;
+        crack_times_seconds.set_item(
+            "online_throttling_100_per_hour",
+            self.crack_times_seconds.online_throttling_100_per_hour,
+        )?;
+        result.set_item("crack_times_seconds", crack_times_seconds)?;
+
+        let crack_times_display = PyDict::new(py);
+        crack_times_display.set_item(
+            "offline_fast_hashing_1e10_per_second",
+            &self.crack_times_display.offline_fast_hashing_1e10_per_second,
+        )?;
+        crack_times_display.set_item(
+            "offline_slow_hashing_1e4_per_second",
+            &self.crack_times_display.offline_slow_hashing_1e4_per_second,
+        )?;
+        crack_times_display.set_item(
+            "online_no_throttling_10_per_second",
+            &self.crack_times_display.online_no_throttling_10_per_second,
+        )?;
+        crack_times_display.set_item(
+            "online_throttling_100_per_hour",
+            &self.crack_times_display.online_throttling_100_per_hour,
+        )?;
+        result.set_item("crack_times_display", crack_times_display)?;
+
+        result.set_item("score", score_to_u8(&self.score))?;
+        result.set_item("calc_time", self.calc_time)?;
+
+        if let Some(feedback) = &self.feedback {
+            let feedback_dict = PyDict::new(py);
+            feedback_dict.set_item(
+                "warning",
+                feedback.warning.as_ref().map(ToString::to_string),
+            )?;
+            let suggestions = feedback
+                .suggestions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>();
+            feedback_dict.set_item("suggestions", suggestions)?;
+            result.set_item("feedback", feedback_dict)?;
+        } else {
+            result.set_item("feedback", py.None())?;
+        }
+
+        Ok(result)
+    }
 }
 
 #[pyfunction]

--- a/tests/test_zxcvbn_rs_py.py
+++ b/tests/test_zxcvbn_rs_py.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from zxcvbn_rs_py import zxcvbn
@@ -12,3 +14,27 @@ from zxcvbn_rs_py import zxcvbn
 def test_zxcvbn_rs_py(password: str, score: int) -> None:
     r = zxcvbn("correcthorsebatterystaple")
     assert r.score == score
+
+
+def test_entropy_to_dict_shape() -> None:
+    result = zxcvbn("correcthorsebatterystaple").to_dict()
+    assert set(result.keys()) == {
+        "guesses",
+        "guesses_log10",
+        "crack_times_seconds",
+        "crack_times_display",
+        "score",
+        "feedback",
+        "calc_time",
+    }
+    assert isinstance(result["score"], int)
+    assert isinstance(result["crack_times_seconds"], dict)
+    assert isinstance(result["crack_times_display"], dict)
+
+
+def test_entropy_to_dict_json_serializable() -> None:
+    weak_result = zxcvbn("password").to_dict()
+    strong_result = zxcvbn("correcthorsebatterystaple").to_dict()
+
+    json.dumps(weak_result)
+    json.dumps(strong_result)

--- a/zxcvbn_rs_py/zxcvbn_rs_py.pyi
+++ b/zxcvbn_rs_py/zxcvbn_rs_py.pyi
@@ -76,6 +76,10 @@ class Entropy:
     calc_time: int
     """How long it took to calculate the answer."""
 
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable dictionary representation."""
+        ...
+
 def zxcvbn(password: str, user_inputs: list[str] | None = None) -> Entropy:
     """
     Measure the strength of a password.


### PR DESCRIPTION
As the title says.

Solves both open Issues: https://github.com/fief-dev/zxcvbn-rs-py/issues/5 and https://github.com/fief-dev/zxcvbn-rs-py/issues/8

## Implementation

Add a `to_dict()` method on the `Entropy` object.

## Usage

```python
>>> import zxcvbn_rs_py as zxcvbn
>>> pw = 'correcthorsebatterystaple'
>>> zxcvbn.zxcvbn(pw)
<zxcvbn_rs_py.Entropy object at 0x109a9a010>
>>>
>>> # Cannot turn into a dict
>>> dict(zxcvbn.zxcvbn(pw))
Traceback (most recent call last):
  File "<python-input-6>", line 1, in <module>
    dict(zxcvbn.zxcvbn(pw))
    ~~~~^^^^^^^^^^^^^^^^^^^
TypeError: 'zxcvbn_rs_py.Entropy' object is not iterable
>>>
>>> # Use of the `.to_dict()` method:
>>> zxcvbn.zxcvbn(pw).to_dict()
{'guesses': 273500327700640, 'guesses_log10': 14.436957851029575, 'crack_times_seconds': {'offline_fast_hashing_1e10_per_second': 27350.032770064, 'offline_slow_hashing_1e4_per_second': 27350032770.064, 'online_no_throttling_10_per_second': 27350032770064.0, 'online_throttling_100_per_hour': 9846011797223040.0}, 'crack_times_display': {'offline_fast_hashing_1e10_per_second': '7 hours', 'offline_slow_hashing_1e4_per_second': 'centuries', 'online_no_throttling_10_per_second': 'centuries', 'online_throttling_100_per_hour': 'centuries'}, 'score': 4, 'calc_time': 7, 'feedback': None}
```

Honest Disclosure. GPT 5.3 did the work. I reviewed and interrogated the agent, and agree on the implementation.